### PR TITLE
Support @extension annotation on paths

### DIFF
--- a/lib/swagger_yard.rb
+++ b/lib/swagger_yard.rb
@@ -104,7 +104,7 @@ module SwaggerYard
       ::YARD::Tags::Library.define_tag("Api resource", :resource)
       ::YARD::Tags::Library.define_tag("Api path", :path, :with_types)
       ::YARD::Tags::Library.define_tag("Parameter", :parameter, :with_types_name_and_default)
-      ::YARD::Tags::Library.define_tag("Extensions", :extensions)
+      ::YARD::Tags::Library.define_tag("Extension", :extension)
       ::YARD::Tags::Library.define_tag("Response type", :response_type, :with_types)
       ::YARD::Tags::Library.define_tag("Error response message", :error_message, :with_types_and_name)
       ::YARD::Tags::Library.define_tag("Response", :response, :with_types_and_name)

--- a/lib/swagger_yard.rb
+++ b/lib/swagger_yard.rb
@@ -104,6 +104,7 @@ module SwaggerYard
       ::YARD::Tags::Library.define_tag("Api resource", :resource)
       ::YARD::Tags::Library.define_tag("Api path", :path, :with_types)
       ::YARD::Tags::Library.define_tag("Parameter", :parameter, :with_types_name_and_default)
+      ::YARD::Tags::Library.define_tag("Extensions", :extensions)
       ::YARD::Tags::Library.define_tag("Response type", :response_type, :with_types)
       ::YARD::Tags::Library.define_tag("Error response message", :error_message, :with_types_and_name)
       ::YARD::Tags::Library.define_tag("Response", :response, :with_types_and_name)

--- a/lib/swagger_yard/operation.rb
+++ b/lib/swagger_yard/operation.rb
@@ -30,8 +30,8 @@ module SwaggerYard
             operation.add_response(tag)
           when "summary"
             operation.summary = tag.text
-          when "extensions"
-            operation.add_extensions(tag)
+          when "extension"
+            operation.add_extension(tag)
           when "example"
             if tag.name && !tag.name.empty?
               operation.response(tag.name).example = tag.text
@@ -175,11 +175,15 @@ module SwaggerYard
 
     ##
     # Example:
-    # @extensions [x-internal: true, x-beta: true]
-    def add_extensions(tag)
-      extension_regex = /\[([\w-]*\:\s[\w-]*)(?:\,\s([\w-]*\:\s[\w-]*))*\]/
-      extension_matches = tag.text.match(extension_regex).captures.compact
-      @extensions = extension_matches.map { |c| c.split(":").map(&:strip) }.to_h
+    # @extension x-internal: true
+    def add_extension(tag)
+      key, value = tag.text.split(":").map(&:strip)
+
+      unless key.start_with?("x-")
+        SwaggerYard.log.warn("extension '#{tag.text}' must being with 'x-'")
+      end
+
+      @extensions[key] = value
     end
 
     private

--- a/lib/swagger_yard/operation.rb
+++ b/lib/swagger_yard/operation.rb
@@ -177,7 +177,7 @@ module SwaggerYard
     # Example:
     # @extension x-internal: true
     def add_extension(tag)
-      key, value = tag.text.split(":").map(&:strip)
+      key, value = tag.text.split(":", 2).map(&:strip)
 
       unless key.start_with?("x-")
         SwaggerYard.log.warn("extension '#{tag.text}' must being with 'x-'")

--- a/spec/fixtures/dummy/app/controllers/pets_controller.rb
+++ b/spec/fixtures/dummy/app/controllers/pets_controller.rb
@@ -36,7 +36,7 @@ class PetsController < ApplicationController
   # delete a Pet
   # @path [DELETE] /pets/{id}
   # @parameter id [integer] The ID for the Pet
-  # @extensions [x-internal: true]
+  # @extension x-internal: true
   # @response 204 successfully deleted
   # @response 404 Not Found
   # @response 401 Unauthorized

--- a/spec/fixtures/dummy/app/controllers/pets_controller.rb
+++ b/spec/fixtures/dummy/app/controllers/pets_controller.rb
@@ -33,6 +33,13 @@ class PetsController < ApplicationController
   # def update
   # end
 
-  # def destroy
-  # end
+  # delete a Pet
+  # @path [DELETE] /pets/{id}
+  # @parameter id [integer] The ID for the Pet
+  # @extensions [x-internal: true]
+  # @response 204 successfully deleted
+  # @response 404 Not Found
+  # @response 401 Unauthorized
+  def destroy
+  end
 end

--- a/spec/lib/swagger_yard/openapi_spec.rb
+++ b/spec/lib/swagger_yard/openapi_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe SwaggerYard::OpenAPI do
 
     it { is_expected.to_not be_empty }
 
-    its(:keys) { are_expected.to eq(["get"]) }
+    its(:keys) { are_expected.to eq(["get", "delete"]) }
 
     its(["get", "summary"]) { is_expected.to eq("return a Pet") }
 
@@ -36,6 +36,12 @@ RSpec.describe SwaggerYard::OpenAPI do
     its(["get", "parameters"]) { are_expected.to include(a_parameter_named("id")) }
 
     its(["get", "security"]) { is_expected.to eq([{'header_x_application_api_key' => []}])}
+
+    its(["delete", "summary"]) { is_expected.to eq("delete a Pet") }
+
+    its(["delete", "operationId"]) { is_expected.to eq("Pet-destroy") }
+
+    its(["delete", "x-internal"]) { is_expected.to eq("true") }
   end
 
   context "#/paths//pets" do

--- a/spec/lib/swagger_yard/operation_spec.rb
+++ b/spec/lib/swagger_yard/operation_spec.rb
@@ -130,7 +130,9 @@ RSpec.describe SwaggerYard::Operation do
   end
 
   context "with an extensions tag" do
-    let(:tags) { [yard_tag("@path [GET] /hello"), yard_tag("@extensions [x-internal: true, x-displayName: User]")] }
+    let(:tags) { [yard_tag("@path [GET] /hello"),
+                  yard_tag("@extension x-internal: true"),
+                  yard_tag("@extension x-displayName: User")] }
 
     subject(:hash) { operation.extended_attributes }
 

--- a/spec/lib/swagger_yard/operation_spec.rb
+++ b/spec/lib/swagger_yard/operation_spec.rb
@@ -129,6 +129,15 @@ RSpec.describe SwaggerYard::Operation do
     its("responses.first.type.source") { is_expected.to eq('ClientError') }
   end
 
+  context "with an extensions tag" do
+    let(:tags) { [yard_tag("@path [GET] /hello"), yard_tag("@extensions [x-internal: true, x-displayName: User]")] }
+
+    subject(:hash) { operation.extended_attributes }
+
+    its(['x-internal'])    { is_expected.to eq('true') }
+    its(['x-displayName']) { is_expected.to eq('User') }
+  end
+
   context "examples" do
     let(:yard_object) { yard_method('index', content) }
 

--- a/spec/lib/swagger_yard/swagger_spec.rb
+++ b/spec/lib/swagger_yard/swagger_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe SwaggerYard::Swagger do
 
     it { is_expected.to_not be_empty }
 
-    its(:keys) { are_expected.to eq(["get"]) }
+    its(:keys) { are_expected.to eq(["get", "delete"]) }
 
     its(["get", "summary"]) { is_expected.to eq("return a Pet") }
 
@@ -43,6 +43,12 @@ RSpec.describe SwaggerYard::Swagger do
     its(["get", "parameters"]) { are_expected.to include(a_parameter_named("id")) }
 
     its(["get", "security"]) { is_expected.to eq([{'header_x_application_api_key' => []}])}
+
+    its(["delete", "summary"]) { is_expected.to eq("delete a Pet") }
+
+    its(["delete", "operationId"]) { is_expected.to eq("Pet-destroy") }
+
+    its(["delete", "x-internal"]) { is_expected.to eq("true") }
   end
 
   context "#/paths//pets" do


### PR DESCRIPTION
### Summary
Extensions are now supported via `@extensions` tag. See [OpenAPI extension docs](https://swagger.io/docs/specification/openapi-extensions/).

For example, this annotation will add an `"x-internal": "true" extension to the path.
```ruby
# @path [GET] /users
# @extensions [x-internal: true]
```

### Test plan

* [x] tests added or updated

