### PR TITLE
Add config to ignore paths marked x-internal

### DIFF
--- a/lib/swagger_yard/api_group.rb
+++ b/lib/swagger_yard/api_group.rb
@@ -80,8 +80,9 @@ module SwaggerYard
 
     def add_path_item(yard_object)
       path = path_from_yard_object(yard_object)
+      operation = Operation.from_yard_object(yard_object, self)
 
-      return if path.nil?
+      return if path.nil? || (operation.internal? && SwaggerYard.config.ignore_internal)
 
       path_item = (path_items[path] ||= PathItem.new(self))
       path_item.add_operation(yard_object)

--- a/lib/swagger_yard/configuration.rb
+++ b/lib/swagger_yard/configuration.rb
@@ -6,6 +6,7 @@ module SwaggerYard
     attr_accessor :controller_path, :model_path
     attr_accessor :path_discovery_function
     attr_accessor :security_definitions
+    attr_accessor :ignore_internal
 
     # openapi-compatible names
     alias openapi_version swagger_version
@@ -20,6 +21,7 @@ module SwaggerYard
       @description = "Configure description with SwaggerYard.config.description"
       @security_definitions = {}
       @external_schema = {}
+      @ignore_internal = false
     end
 
     def external_schema(mappings = nil)

--- a/lib/swagger_yard/operation.rb
+++ b/lib/swagger_yard/operation.rb
@@ -186,6 +186,10 @@ module SwaggerYard
       @extensions[key] = value
     end
 
+    def internal?
+      extensions["x-internal"] == 'true'
+    end
+
     private
     def parse_path_params(path)
       path.scan(/\{([^\}]+)\}/).flatten

--- a/spec/lib/swagger_yard/openapi_spec.rb
+++ b/spec/lib/swagger_yard/openapi_spec.rb
@@ -42,6 +42,12 @@ RSpec.describe SwaggerYard::OpenAPI do
     its(["delete", "operationId"]) { is_expected.to eq("Pet-destroy") }
 
     its(["delete", "x-internal"]) { is_expected.to eq("true") }
+
+    context "when ignoring internal paths" do
+      before { SwaggerYard.config.ignore_internal = true }
+
+      its(:keys) { are_expected.to eq(["get"]) }
+    end
   end
 
   context "#/paths//pets" do

--- a/spec/lib/swagger_yard/swagger_spec.rb
+++ b/spec/lib/swagger_yard/swagger_spec.rb
@@ -49,6 +49,12 @@ RSpec.describe SwaggerYard::Swagger do
     its(["delete", "operationId"]) { is_expected.to eq("Pet-destroy") }
 
     its(["delete", "x-internal"]) { is_expected.to eq("true") }
+
+    context "when ignoring internal paths" do
+      before { SwaggerYard.config.ignore_internal = true }
+
+      its(:keys) { are_expected.to eq(["get"]) }
+    end
   end
 
   context "#/paths//pets" do


### PR DESCRIPTION
### Summary
This is rebased on https://github.com/netlify/swagger_yard/pull/3.

* Adds new config called `ignore_internal`.
* When `ignore_internal` is true, any path with the `x-internal` extension will not be included in the openapi document.

### Test plan

* [x] tests added or updated
