### PR TITLE
Support redoc x-tagGroups extension

### DIFF
--- a/lib/swagger_yard.rb
+++ b/lib/swagger_yard.rb
@@ -116,6 +116,7 @@ module SwaggerYard
       ::YARD::Tags::Library.define_tag("Additional properties", :additional_properties)
       ::YARD::Tags::Library.define_tag("Authorization", :authorization, :with_types_and_name)
       ::YARD::Tags::Library.define_tag("Authorization Use", :authorize_with)
+      ::YARD::Tags::Library.define_tag("Tag group", :tag_group)
       # @example is a core YARD tag, let's use it
       # ::YARD::Tags::Library.define_tag("Example", :example, :with_title_and_text)
       ::YARD::Tags::Library.define_directive(:model, :with_title_and_text, Directives::ParamClassDirective)

--- a/lib/swagger_yard/api_group.rb
+++ b/lib/swagger_yard/api_group.rb
@@ -24,7 +24,7 @@ module SwaggerYard
 
   class ApiGroup
     attr_accessor :description, :resource
-    attr_reader :path_items, :authorizations, :class_name
+    attr_reader :path_items, :authorizations, :class_name, :tag_group
 
     def self.from_yard_object(yard_object)
       new.add_yard_object(yard_object)
@@ -69,6 +69,10 @@ module SwaggerYard
 
       if tag = yard_object.tags.detect {|t| t.tag_name == "resource"}
         @resource = tag.text
+      end
+
+      if tag = yard_object.tags.detect {|t| t.tag_name == "tag_group"}
+        @tag_group = tag.text
       end
 
       # we only have api_key auth, the value for now is always empty array

--- a/lib/swagger_yard/openapi.rb
+++ b/lib/swagger_yard/openapi.rb
@@ -17,11 +17,13 @@ module SwaggerYard
     end
 
     def definitions
-      {
+      defs = {
         "paths" => paths(specification.path_objects),
         "tags" => tags(specification.tag_objects),
         "components" => components
       }
+      defs["x-tagGroups"] = specification.tag_groups if specification.tag_groups
+      defs
     end
 
     def components

--- a/lib/swagger_yard/specification.rb
+++ b/lib/swagger_yard/specification.rb
@@ -54,7 +54,7 @@ module SwaggerYard
     end
 
     def api_groups
-      @api_groups ||= parse_controllers
+      @api_groups ||= parse_controllers.select { |group| group.path_items.present? }
     end
 
     def parse_models

--- a/lib/swagger_yard/specification.rb
+++ b/lib/swagger_yard/specification.rb
@@ -22,6 +22,23 @@ module SwaggerYard
       api_groups.map(&:tag)
     end
 
+    def tag_groups
+      return if api_groups.none?(&:tag_group)
+
+      groups = {}
+      api_groups.each do |group|
+        groups[group.tag_group] ||= []
+        groups[group.tag_group] << group.resource
+      end
+
+      groups.map do |name, tags|
+        {
+          name: name,
+          tags: tags
+        }
+      end
+    end
+
     def model_objects
       Hash[models.map {|m| [m.id, m]}]
     end

--- a/spec/fixtures/dummy/app/controllers/pets_controller.rb
+++ b/spec/fixtures/dummy/app/controllers/pets_controller.rb
@@ -3,6 +3,7 @@
 # This document describes the API for interacting with Pet resources
 #
 # @authorize_with header_x_application_api_key
+# @tag_group Test Tag Group
 #
 class PetsController < ApplicationController
   # return a list of Pets

--- a/spec/fixtures/dummy/app/controllers/transport_controller.rb
+++ b/spec/fixtures/dummy/app/controllers/transport_controller.rb
@@ -3,6 +3,7 @@
 # This document describes the API for interacting with Transport resources
 #
 # @authorize_with header_x_application_api_key
+# @tag_group Test Tag Group
 #
 class TransportsController < ApplicationController
   # return a list of Transports

--- a/spec/lib/swagger_yard/openapi_spec.rb
+++ b/spec/lib/swagger_yard/openapi_spec.rb
@@ -133,6 +133,12 @@ RSpec.describe SwaggerYard::OpenAPI do
     it { is_expected.to include(a_tag_named("Pet"), a_tag_named("Transport"))}
   end
 
+  context "#/tag_groups" do
+    subject { openapi["x-tagGroups"] }
+
+    it { is_expected.to eq([{:name=>"Test Tag Group", :tags=>["Pet", "Transport"]}])}
+  end
+
   context "#/components/securitySchemes" do
     subject { openapi["components"]["securitySchemes"] }
 
@@ -145,7 +151,8 @@ RSpec.describe SwaggerYard::OpenAPI do
   context 'securityDefinitions' do
     let(:auth) { SwaggerYard::Authorization.from_yard_object(yard_tag(content)) }
     let(:spec) { stub(path_objects: SwaggerYard::Paths.new([]), tag_objects: [],
-                      security_objects: { auth.id => auth }, model_objects: {}) }
+                      security_objects: { auth.id => auth }, model_objects: {},
+                      tag_groups: []) }
     let (:security_schemes) { {'key' => {'type' => 'basic', 'description' => 'Basic authentication'} } }
     let(:content) { '@authorization [api_key] header X-My-Header' }
 

--- a/spec/lib/swagger_yard/specification_spec.rb
+++ b/spec/lib/swagger_yard/specification_spec.rb
@@ -44,6 +44,34 @@ RSpec.describe SwaggerYard::Specification, "reparsing" do
     SRC
   end
 
+  let(:tag_groups) do
+    <<-SRC
+      # @resource Foo
+      # @tag_group One
+      class FooController
+        # @path [GET] /hello
+        def index
+        end
+      end
+
+      # @resource Bar
+      # @tag_group One
+      class BarController
+        # @path [GET] /hello
+        def index
+        end
+      end
+
+      # @resource Baz
+      # @tag_group Two
+      class BazController
+        # @path [GET] /hello
+        def index
+        end
+      end
+    SRC
+  end
+
   it "reparses after changes to a file" do
     File.open(filename, "w") { |f| f.write first_pass }
 
@@ -80,6 +108,20 @@ RSpec.describe SwaggerYard::Specification, "reparsing" do
       spec = specification
       spec.instance_variable_set(:@api_groups, [api_group])
       spec.path_objects
+    end
+  end
+
+  context '#group_tags' do
+    it 'returns array when tag groups are present' do
+      File.open(filename, "w") { |f| f.write tag_groups }
+
+      expect(specification.tag_groups).to eq([{:name=>"One", :tags=>["Foo", "Bar"]}, {:name=>"Two", :tags=>["Baz"]}])
+    end
+
+    it 'returns nil when tag groups are not present' do
+      File.open(filename, "w") { |f| f.write first_pass }
+
+      expect(specification.tag_groups).to be_nil
     end
   end
 end


### PR DESCRIPTION
### Summary
This PR will allow you to specify a `@tag_group` on a `@resource` and generate the appropriate `x-tagGroups` vender extension definition.

```ruby
    # @resource Deploy
    # @tag_group Deploys
```

### Test plan

* [x] tests added or updated
