### PR TITLE
Allow extensions on properties, ignore internal

### DIFF
--- a/lib/swagger_yard/model.rb
+++ b/lib/swagger_yard/model.rb
@@ -54,7 +54,9 @@ module SwaggerYard
           @id = Model.mangle(tag.text) unless tag.text.empty?
         when "property"
           prop = Property.from_tag(tag)
-          @properties << prop if prop
+          if prop && !(prop.internal? && SwaggerYard.config.ignore_internal)
+            @properties << prop
+          end
         when "discriminator"
           prop = Property.from_tag(tag)
           if prop

--- a/lib/swagger_yard/property.rb
+++ b/lib/swagger_yard/property.rb
@@ -4,7 +4,7 @@ module SwaggerYard
   #
   class Property
     include Example
-    attr_reader :name, :required, :type, :nullable
+    attr_reader :name, :required, :type, :nullable, :extensions
     attr_accessor :description
 
     NAME_OPTIONS_REGEXP = /[\(\)]/
@@ -60,11 +60,29 @@ module SwaggerYard
       @name, @description = name, description
       @required = options.include?('required')
       @nullable = options.include?('nullable')
+      @extensions = parse_extensions(options.select { |option| option.start_with?("x-") })
       @type = Type.from_type_list(types)
     end
 
-     def required?
+    def required?
       @required
+    end
+
+    def internal?
+      extensions["x-internal"] == 'true'
+    end
+
+    private
+
+    def parse_extensions(options)
+      return {} unless options.present?
+
+      extensions = {}
+      options.each do |option|
+        key, value = option.split(":", 2).map(&:strip)
+        extensions[key] = value
+      end
+      extensions
     end
   end
 end

--- a/lib/swagger_yard/swagger.rb
+++ b/lib/swagger_yard/swagger.rb
@@ -172,6 +172,9 @@ module SwaggerYard
               h["type"] = [h["type"], "null"]
             end
           end
+          if prop.extensions.present?
+            h.merge!(prop.extensions)
+          end
           h["example"] = prop.example if prop.example
         end
       end

--- a/spec/fixtures/dummy/app/models/pet.rb
+++ b/spec/fixtures/dummy/app/models/pet.rb
@@ -14,6 +14,7 @@
 # @property birthday            [date]                the pet's birthday
 # @example birthday
 #   "2018/10/31T00:00:00.000Z"
+# @property secret_name(x-internal:true) [string]          the pet's secret name
 #
 class Pet
 end

--- a/spec/lib/swagger_yard/openapi_spec.rb
+++ b/spec/lib/swagger_yard/openapi_spec.rb
@@ -99,10 +99,17 @@ RSpec.describe SwaggerYard::OpenAPI do
 
     its(["AnimalThing", "properties"]) { are_expected.to include("id", "type", "possessions") }
 
-    its(["Pet", "properties"]) { are_expected.to include("id", "names", "age", "relatives") }
+    its(["Pet", "properties"]) { are_expected.to include("id", "names", "age", "relatives", "secret_name") }
     its(["Pet", "properties", "names", "example"]) { is_expected.to eq(["Bob", "Bobo", "Bobby"]) }
     its(["Pet", "properties", "age", "example"]) { is_expected.to eq(8) }
     its(["Pet", "properties", "birthday", "example"]) { is_expected.to eq("2018/10/31T00:00:00.000Z") }
+    its(["Pet", "properties", "secret_name", "x-internal"]) { is_expected.to eq("true") }
+
+    context "when ignoring internal properties" do
+      before { SwaggerYard.config.ignore_internal = true }
+
+      its(["Pet", "properties"]) { are_expected.to_not include("secret_name") }
+    end
 
     its(["Possession", "properties"]) { are_expected.to include("name", "value") }
 

--- a/spec/lib/swagger_yard/property_spec.rb
+++ b/spec/lib/swagger_yard/property_spec.rb
@@ -73,6 +73,14 @@ describe SwaggerYard::Property, 'from_tag' do
     it { is_expected.to be_required }
   end
 
+  context "with a extensions" do
+    subject { property }
+    let(:tag) { yard_tag '@property name(required,x-internal:true) [string]  Name' }
+
+    it { is_expected.to be_required }
+    it { is_expected.to be_internal }
+  end
+
   context "with no description" do
     let(:tag) { yard_tag '@property myProperty [string]' }
 


### PR DESCRIPTION
### Summary
This PR allows extensions to be added as options for a parameter:
```ruby
# @property site_jwt_secret(x-internal:true) [string]
```

Multiple extensions can be added in addition to other supported options

```ruby
# @property site_jwt_secret(required,x-internal:true,x-something:false) [string]
```

If `x-internal` is specific on a parameter, and the `ingnore_internal` configuration is set (`SwaggerYard.config.ignore_internal = true`), that parameter will be omitted from the specification.

### Test plan

* [x] tests added or updated
