### PR TITLE
Allow for customized operationId and empty summary

### DIFF
--- a/lib/swagger_yard.rb
+++ b/lib/swagger_yard.rb
@@ -109,6 +109,7 @@ module SwaggerYard
       ::YARD::Tags::Library.define_tag("Error response message", :error_message, :with_types_and_name)
       ::YARD::Tags::Library.define_tag("Response", :response, :with_types_and_name)
       ::YARD::Tags::Library.define_tag("Api Summary", :summary)
+      ::YARD::Tags::Library.define_tag("Operation id", :operation_id)
       ::YARD::Tags::Library.define_tag("Model resource", :model)
       ::YARD::Tags::Library.define_tag("Model superclass", :inherits)
       ::YARD::Tags::Library.define_tag("Model property", :property, :with_types_name_and_default)

--- a/lib/swagger_yard/configuration.rb
+++ b/lib/swagger_yard/configuration.rb
@@ -7,6 +7,7 @@ module SwaggerYard
     attr_accessor :path_discovery_function
     attr_accessor :security_definitions
     attr_accessor :ignore_internal
+    attr_accessor :default_summary_to_description
 
     # openapi-compatible names
     alias openapi_version swagger_version

--- a/lib/swagger_yard/configuration.rb
+++ b/lib/swagger_yard/configuration.rb
@@ -23,6 +23,7 @@ module SwaggerYard
       @security_definitions = {}
       @external_schema = {}
       @ignore_internal = false
+      @default_summary_to_description = true
     end
 
     def external_schema(mappings = nil)

--- a/lib/swagger_yard/operation.rb
+++ b/lib/swagger_yard/operation.rb
@@ -7,6 +7,7 @@ module SwaggerYard
   class Operation
     attr_accessor :description, :ruby_method
     attr_writer :summary
+    attr_writer :operation_id
     attr_reader :path, :http_method
     attr_reader :parameters
     attr_reader :path_item, :responses, :extensions
@@ -30,6 +31,8 @@ module SwaggerYard
             operation.add_response(tag)
           when "summary"
             operation.summary = tag.text
+          when "operation_id"
+            operation.operation_id = tag.text
           when "extension"
             operation.add_extension(tag)
           when "example"
@@ -48,6 +51,7 @@ module SwaggerYard
     def initialize(path_item)
       @path_item      = path_item
       @summary        = nil
+      @operation_id  = nil
       @description    = ""
       @parameters     = []
       @default_response = nil
@@ -60,7 +64,7 @@ module SwaggerYard
     end
 
     def operation_id
-      "#{api_group.resource}-#{ruby_method}"
+      @operation_id || "#{api_group.resource}-#{ruby_method}"
     end
 
     def api_group

--- a/lib/swagger_yard/operation.rb
+++ b/lib/swagger_yard/operation.rb
@@ -60,7 +60,7 @@ module SwaggerYard
     end
 
     def summary
-      @summary || description.split("\n\n").first || ""
+      @summary || default_summary
     end
 
     def operation_id
@@ -197,6 +197,14 @@ module SwaggerYard
     private
     def parse_path_params(path)
       path.scan(/\{([^\}]+)\}/).flatten
+    end
+
+    def default_summary
+      if SwaggerYard.config.default_summary_to_description
+        description.split("\n\n").first || ""
+      else
+        ""
+      end
     end
   end
 end

--- a/spec/fixtures/dummy/app/controllers/pets_controller.rb
+++ b/spec/fixtures/dummy/app/controllers/pets_controller.rb
@@ -31,6 +31,18 @@ class PetsController < ApplicationController
   def create
   end
 
+  # update a Pet
+  # @path [PUT] /pets/{id}
+  # @operation_id updatePet
+  # @parameter id [integer] The ID for the Pet
+  # @parameter pet(required,body) [Pet] The pet object
+  # @response_type [Pet]
+  # @error_message [EmptyPet] 404 Pet not found
+  # @error_message 400 Invalid ID supplied
+  def update
+  end
+
+
   # def update
   # end
 

--- a/spec/lib/swagger_yard/openapi_spec.rb
+++ b/spec/lib/swagger_yard/openapi_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe SwaggerYard::OpenAPI do
 
     it { is_expected.to_not be_empty }
 
-    its(:keys) { are_expected.to eq(["get", "delete"]) }
+    its(:keys) { are_expected.to eq(["get", "put", "delete"]) }
 
     its(["get", "summary"]) { is_expected.to eq("return a Pet") }
 
@@ -37,6 +37,10 @@ RSpec.describe SwaggerYard::OpenAPI do
 
     its(["get", "security"]) { is_expected.to eq([{'header_x_application_api_key' => []}])}
 
+    its(["put", "summary"]) { is_expected.to eq("update a Pet") }
+
+    its(["put", "operationId"]) { is_expected.to eq("updatePet") }
+
     its(["delete", "summary"]) { is_expected.to eq("delete a Pet") }
 
     its(["delete", "operationId"]) { is_expected.to eq("Pet-destroy") }
@@ -46,7 +50,7 @@ RSpec.describe SwaggerYard::OpenAPI do
     context "when ignoring internal paths" do
       before { SwaggerYard.config.ignore_internal = true }
 
-      its(:keys) { are_expected.to eq(["get"]) }
+      its(:keys) { are_expected.to eq(["get", "put"]) }
     end
   end
 

--- a/spec/lib/swagger_yard/openapi_spec.rb
+++ b/spec/lib/swagger_yard/openapi_spec.rb
@@ -151,9 +151,10 @@ RSpec.describe SwaggerYard::OpenAPI do
   end
 
   context "#/tag_groups" do
-    subject { openapi["x-tagGroups"] }
+    subject { openapi["x-tagGroups"][0] }
 
-    it { is_expected.to eq([{:name=>"Test Tag Group", :tags=>["Pet", "Transport"]}])}
+    its([:name]) { is_expected.to eq("Test Tag Group")}
+    its([:tags]) { is_expected.to match_array(["Pet", "Transport"])}
   end
 
   context "#/components/securitySchemes" do

--- a/spec/lib/swagger_yard/openapi_spec.rb
+++ b/spec/lib/swagger_yard/openapi_spec.rb
@@ -52,6 +52,12 @@ RSpec.describe SwaggerYard::OpenAPI do
 
       its(:keys) { are_expected.to eq(["get", "put"]) }
     end
+
+    context "when not defaulting summary to description" do
+      before { SwaggerYard.config.default_summary_to_description = false }
+
+      its(["put", "summary"]) { is_expected.to be_nil }
+    end
   end
 
   context "#/paths//pets" do

--- a/spec/lib/swagger_yard/swagger_spec.rb
+++ b/spec/lib/swagger_yard/swagger_spec.rb
@@ -59,6 +59,12 @@ RSpec.describe SwaggerYard::Swagger do
 
       its(:keys) { are_expected.to eq(["get", "put"]) }
     end
+
+    context "when not defaulting summary to description" do
+      before { SwaggerYard.config.default_summary_to_description = false }
+
+      its(["put", "summary"]) { is_expected.to be_nil }
+    end
   end
 
   context "#/paths//pets" do

--- a/spec/lib/swagger_yard/swagger_spec.rb
+++ b/spec/lib/swagger_yard/swagger_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe SwaggerYard::Swagger do
 
     it { is_expected.to_not be_empty }
 
-    its(:keys) { are_expected.to eq(["get", "delete"]) }
+    its(:keys) { are_expected.to eq(["get", "put", "delete"]) }
 
     its(["get", "summary"]) { is_expected.to eq("return a Pet") }
 
@@ -44,6 +44,10 @@ RSpec.describe SwaggerYard::Swagger do
 
     its(["get", "security"]) { is_expected.to eq([{'header_x_application_api_key' => []}])}
 
+    its(["put", "summary"]) { is_expected.to eq("update a Pet") }
+
+    its(["put", "operationId"]) { is_expected.to eq("updatePet") }
+
     its(["delete", "summary"]) { is_expected.to eq("delete a Pet") }
 
     its(["delete", "operationId"]) { is_expected.to eq("Pet-destroy") }
@@ -53,7 +57,7 @@ RSpec.describe SwaggerYard::Swagger do
     context "when ignoring internal paths" do
       before { SwaggerYard.config.ignore_internal = true }
 
-      its(:keys) { are_expected.to eq(["get"]) }
+      its(:keys) { are_expected.to eq(["get", "put"]) }
     end
   end
 


### PR DESCRIPTION
### Summary
These are two changes needed to support our use of swagger yard.

If an `@operation_id` is provided for an endpoint, this value will be used instead of the default, which was `"#{api_group.resource}-#{ruby_method}"`.

In addition, swaagger-yard defaults the `summary` to the `description` if a `@summary` was not provided on the endpoint. For our purposes, we want the `@summary` to be omitted so the `operationId` will instead be displayed by redoc in the sidebar. I've added a `default_summary_to_description` config that when set to false, will not set a `@summary` unless explicitly provided.

See https://github.com/netlify/bitballoon/issues/9858 for more details.

Pop. over here to see it in action: https://github.com/netlify/bitballoon/pull/9977

### Test plan

* [x] tests added or updated

### Relevant links (GH issues, etc.) or a picture of cute animal
![image](https://user-images.githubusercontent.com/1810909/122304035-c8ee4300-cec1-11eb-9ed7-121358caffb0.png)
